### PR TITLE
Fix token recognition error

### DIFF
--- a/chalk/consts.bal
+++ b/chalk/consts.bal
@@ -10,7 +10,7 @@
 
 @final string REVERSE_CODE = "7;";
 
-@final string ESCAPE_PREFIX = "\033[";
+@final string ESCAPE_PREFIX = "\u001B[";
 @final string ESCAPE_SUFFIX = "m";
 
 @final string RESET_ALL_CODE = ESCAPE_PREFIX + RESET_CODE + ESCAPE_SUFFIX;


### PR DESCRIPTION
## Description
With the latest ballerina chnages; compiling this library throws below errors;
```
error: shan1024/chalk:0.1.3/consts.bal:13:31: token recognition error at: '"\0'
error: shan1024/chalk:0.1.3/consts.bal:13:36: mismatched input '['. expecting {'but', ';', '?', '+', '-', '*', '/', '%', '==', '!=', '>', '<', '>=', '<=', '&&', '||', '&', '^', '...', '|', '?:', '..<'}
error: shan1024/chalk:0.1.3/consts.bal:14:33: token recognition error at: '";\n\n@final string RESET_ALL_CODE = ESCAPE_PREFIX + RESET_CODE + ESCAPE_SUFFIX;\n'
error: shan1024/chalk:0.1.3/consts.bal:17:1: mismatched input '<EOF>'. expecting Identifier
compilation contains errors
```
## Approach
Moved to a unicode escape character. Thus this PR resolves https://github.com/Shan1024/chalk/issues/1